### PR TITLE
chore(phpstan): Configure PHPStan level and ignore errors

### DIFF
--- a/src/phpstan.neon
+++ b/src/phpstan.neon
@@ -14,8 +14,11 @@ includes:
     - ../../../../vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
-    level: max
+    level: 9
     checkExplicitMixed: false
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: phpDoc.parseError
+        - identifier: arrayFilter.strict
+        - identifier: arrayFilter.same


### PR DESCRIPTION
- Set analysis level to 9.
- Ignore specific errors for missing iterable value types, PHPDoc parsing, and strict array_filter usage.
- This adjustment helps manage current strictness while allowing for future improvements.