### PR TITLE
test(ci): Update PHP versions and fix workflow tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '7 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +32,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -77,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -111,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -97,7 +97,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -131,7 +131,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/src/PHPUnit/TraitGithubActions.php
+++ b/src/PHPUnit/TraitGithubActions.php
@@ -19,12 +19,9 @@ namespace JBZoo\Codestyle\PHPUnit;
 use function JBZoo\Data\yml;
 use function JBZoo\PHPUnit\isSame;
 
-/**
- * @phan-file-suppress PhanUndeclaredProperty
- */
 trait TraitGithubActions
 {
-    public function testGithubActionsWorkflow(): void
+    public static function testGithubActionsWorkflow(): void
     {
         $mailYmlPath = PROJECT_ROOT . '/.github/workflows/main.yml';
         $actual      = yml($mailYmlPath)->getArrayCopy();
@@ -42,7 +39,6 @@ trait TraitGithubActions
             'on'   => [
                 'pull_request' => ['branches' => ['*']],
                 'push'         => ['branches' => ['master']],
-                'schedule'     => [['cron' => $this->getScheduleMinute()]],
             ],
 
             'jobs' => [
@@ -128,11 +124,6 @@ trait TraitGithubActions
         }
     }
 
-    protected function getScheduleMinute(): string
-    {
-        return self::stringToNumber($this->packageName, 59) . ' */8 * * *';
-    }
-
     protected static function stepBeforeTests(): ?array
     {
         return null;
@@ -159,7 +150,7 @@ trait TraitGithubActions
 
     protected static function phpVersions(): array
     {
-        return [8.1, 8.2, 8.3];
+        return [8.2, 8.3, 8.4];
     }
 
     /**
@@ -224,14 +215,5 @@ trait TraitGithubActions
     private static function toYaml(array $data): string
     {
         return (string)yml(self::normalizeData($data));
-    }
-
-    private static function stringToNumber(string $string, int $maxNumber): int
-    {
-        $hash   = \md5($string);
-        $substr = \substr($hash, 0, 8);
-        $number = \hexdec($substr);
-
-        return $number % ($maxNumber + 1);
     }
 }

--- a/src/PHPUnit/TraitGithubActions.php
+++ b/src/PHPUnit/TraitGithubActions.php
@@ -191,7 +191,7 @@ trait TraitGithubActions
     {
         return [
             'name'              => 'Upload Artifacts',
-            'uses'              => 'actions/upload-artifact@v3',
+            'uses'              => 'actions/upload-artifact@v4',
             'continue-on-error' => true,
             'with'              => ['name' => $stepName, 'path' => 'build/'],
         ];

--- a/src/PHPUnit/TraitReadme.php
+++ b/src/PHPUnit/TraitReadme.php
@@ -120,13 +120,13 @@ trait TraitReadme
             }
         }
 
-        $expectedBadgeLine = \implode("\n", [
+        $expectedBadgeLine = \str_replace("    \n", "\n", \implode("\n", [
             $this->getTitle(),
             '',
             \trim(\implode('', \array_filter($expectedBadges))),
             '',
             '',
-        ]);
+        ]));
 
         isFileContains($expectedBadgeLine, PROJECT_ROOT . '/README.md');
     }


### PR DESCRIPTION
- Update PHP versions in CI workflows from 8.1-8.3 to 8.2-8.4.
- Remove the unnecessary scheduled CI job.
- Adjust `TraitGithubActions` to validate the updated workflow configuration.
- Fix badge line formatting in `TraitReadme` test.