### PR TITLE
ci(github-actions): Add read permissions to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+    contents: read
 
 on:
   pull_request:

--- a/src/PHPUnit/TraitGithubActions.php
+++ b/src/PHPUnit/TraitGithubActions.php
@@ -35,8 +35,11 @@ trait TraitGithubActions
 
         // Expected
         $expected = [
-            'name' => 'CI',
-            'on'   => [
+            'name'        => 'CI',
+            'permissions' => [
+                'contents' => 'read',
+            ],
+            'on' => [
                 'pull_request' => ['branches' => ['*']],
                 'push'         => ['branches' => ['master']],
             ],


### PR DESCRIPTION
Explicitly grant `contents: read` to the CI workflow. This is a security best practice and ensures that actions requiring repository content access (e.g., checkout) function correctly without relying on default permissions.