### PR TITLE
refactor(badges): Reformat README badges for clarity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@
 
 name: CI
 permissions:
-    contents: read
+  contents: read
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # JBZoo / Codestyle
 
-[![CI](https://github.com/JBZoo/Codestyle/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Codestyle/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Codestyle/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Codestyle?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Codestyle/coverage.svg)](https://shepherd.dev/github/JBZoo/Codestyle)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Codestyle/level.svg)](https://shepherd.dev/github/JBZoo/Codestyle)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/codestyle/badge)](https://www.codefactor.io/repository/github/jbzoo/codestyle/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/codestyle/version)](https://packagist.org/packages/jbzoo/codestyle/)    [![Total Downloads](https://poser.pugx.org/jbzoo/codestyle/downloads)](https://packagist.org/packages/jbzoo/codestyle/stats)    [![Dependents](https://poser.pugx.org/jbzoo/codestyle/dependents)](https://packagist.org/packages/jbzoo/codestyle/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/codestyle)](https://github.com/JBZoo/Codestyle/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Codestyle/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Codestyle/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Codestyle/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Codestyle?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Codestyle/coverage.svg)](https://shepherd.dev/github/JBZoo/Codestyle)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Codestyle/level.svg)](https://shepherd.dev/github/JBZoo/Codestyle)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/codestyle/badge)](https://www.codefactor.io/repository/github/jbzoo/codestyle/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/codestyle/version)](https://packagist.org/packages/jbzoo/codestyle/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/codestyle/downloads)](https://packagist.org/packages/jbzoo/codestyle/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/codestyle/dependents)](https://packagist.org/packages/jbzoo/codestyle/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/codestyle)](https://github.com/JBZoo/Codestyle/blob/master/LICENSE)
+
 
 Comprehensive collection of QA tools and code quality standards for PHP 8.2+ projects. Provides configurations and wrappers for PHPStan, Psalm, PHP-CS-Fixer, PHPUnit, PHPMD, Phan and other popular code analysis tools.
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,5 +26,7 @@
         <PossiblyUnusedMethod errorLevel="suppress"/>
         <InvalidOperand errorLevel="suppress"/>
         <MissingOverrideAttribute errorLevel="suppress"/>
+        <UnusedClass errorLevel="suppress"/>
+        <PossiblyUnusedReturnValue errorLevel="suppress"/>
     </issueHandlers>
 </psalm>

--- a/src/PHPUnit/TraitReadme.php
+++ b/src/PHPUnit/TraitReadme.php
@@ -112,7 +112,7 @@ trait TraitReadme
                     /** @phpstan-ignore-next-line */
                     $tmpBadge = $this->{$testMethod}();
                     if ($tmpBadge !== null) {
-                        $expectedBadges[$badgeName] = "{$tmpBadge}    ";
+                        $expectedBadges[$badgeName] = "{$tmpBadge}";
                     }
                 } else {
                     fail("Method not found: '{$testMethod}'");
@@ -120,13 +120,12 @@ trait TraitReadme
             }
         }
 
-        $expectedBadgeLine = \str_replace("    \n", "\n", \implode("\n", [
+        $expectedBadgeLine = \implode("\n", [
             $this->getTitle(),
             '',
-            \trim(\implode('', \array_filter($expectedBadges))),
+            \trim(\implode("\n", \array_filter($expectedBadges))),
             '',
-            '',
-        ]));
+        ]);
 
         isFileContains($expectedBadgeLine, PROJECT_ROOT . '/README.md');
     }

--- a/src/PHPUnit/TraitReadme.php
+++ b/src/PHPUnit/TraitReadme.php
@@ -112,7 +112,7 @@ trait TraitReadme
                     /** @phpstan-ignore-next-line */
                     $tmpBadge = $this->{$testMethod}();
                     if ($tmpBadge !== null) {
-                        $expectedBadges[$badgeName] = "{$tmpBadge}";
+                        $expectedBadges[$badgeName] = $tmpBadge;
                     }
                 } else {
                     fail("Method not found: '{$testMethod}'");
@@ -123,7 +123,7 @@ trait TraitReadme
         $expectedBadgeLine = \implode("\n", [
             $this->getTitle(),
             '',
-            \trim(\implode("\n", \array_filter($expectedBadges))),
+            \str_replace("\n\n", "\n", \trim(\implode("\n", \array_filter($expectedBadges)))),
             '',
         ]);
 


### PR DESCRIPTION
- Display each badge on a new line in `README.md`.
- Update `TraitReadme.php` to generate badges without trailing spaces and ensure proper newline separation.
- Suppress `UnusedClass` and `PossiblyUnusedReturnValue` in `psalm.xml`.
- Correct indentation in `main.yml` workflow permissions.